### PR TITLE
Fixes/Changes

### DIFF
--- a/docs/chrome-extension/css/viewonly_joint.css
+++ b/docs/chrome-extension/css/viewonly_joint.css
@@ -4,7 +4,7 @@
    user-select: none;
 }
 [magnet=true]:not(.element) {
-   cursor: crosshair;
+   cursor: pointer;
 }
 [magnet=true]:not(.element):hover {
    opacity: .7;
@@ -12,7 +12,7 @@
 
 .element {
    /* Give the user a hint that he can drag&drop the element. */
-   cursor: move;
+   cursor: pointer;
 }
 
 .element * {
@@ -51,7 +51,7 @@
 /* <g> element wrapping .marker-vertex-group. */
 .marker-vertices {
    opacity: 0;
-   cursor: move;
+   cursor: pointer;
 }
 .marker-arrowheads {
    display: none;      /* setting `display: none` on .marker-arrowheads effectivelly switches of links reconnecting */
@@ -163,7 +163,7 @@
     stroke-linecap: round;
     stroke-linejoin: round;
     opacity: 0;
-    cursor: move;
+    cursor: pointer;
 }
 
 .link.joint-theme-default .connection {
@@ -220,7 +220,7 @@
     stroke-linecap: round;
     stroke-linejoin: round;
     opacity: 0;
-    cursor: move;
+    cursor: pointer;
 }
 .link.joint-theme-material .connection-wrap:hover {
     opacity: .4;
@@ -276,7 +276,7 @@
     stroke-linecap: round;
     stroke-linejoin: round;
     opacity: 0;
-    cursor: move;
+    cursor: pointer;
 }
 .link.joint-theme-modern .connection-wrap:hover {
     opacity: .4;

--- a/docs/chrome-extension/js/main.js
+++ b/docs/chrome-extension/js/main.js
@@ -1,5 +1,5 @@
 chrome.app.runtime.onLaunched.addListener(function(launchData) {
-  chrome.app.window.create('objects.html', {id:"temp", innerBounds: {width: 1024, height: 758}}, function(win) {
+  var a = chrome.app.window.create('objects.html', {id:"temp", innerBounds: {width: 1024, height: 758}}, function(win) {
     win.contentWindow.launchData = launchData;
   });
 });

--- a/docs/chrome-extension/js/templates/tilda_schema/_new.html
+++ b/docs/chrome-extension/js/templates/tilda_schema/_new.html
@@ -1,6 +1,7 @@
 <div>
-  <a name="schema-file">Click me </a>
+  <a name="schema-file"><h3>Click me </h3> </a>
 </div>
+<div class="fName"></div>
 
 <div>
   <input type="radio" name="showObj" value="object" checked="checked"> Object<br/>
@@ -9,6 +10,8 @@
 <div>
   <button class="saveSchema">Save</button>
 </div>
+
+<div class="messages"></div>
 
 <div class="objects">
   <div id="obj_c" class="obj"> </div>

--- a/docs/chrome-extension/manifest.json
+++ b/docs/chrome-extension/manifest.json
@@ -10,15 +10,6 @@
     }
   },
   "permissions": [
-    {"fileSystem": ["write", "retainEntries", "directory"]},
-    "storage",
-    "unlimitedStorage"
-  ],
-  "file_handlers": {
-    "text": {
-      "types": [
-          "text/*"
-      ]
-    }
-  }
+    {"fileSystem": ["write", "retainEntries", "directory"]}
+  ]
 }

--- a/src/tilda/generation/graphviz/GraphvizUtil.java
+++ b/src/tilda/generation/graphviz/GraphvizUtil.java
@@ -981,6 +981,7 @@ public class GraphvizUtil
       	writer.println("  }");
       	writer.println(" })()");
       	writer.println("</SCRIPT>");
+        writer.println("<a href='#' style='cursor: pointer; z-index: 1000; position:fixed; right:0px; bottom:0; margin:0px; padding:0px;'>Goto top</a>");
         writer.println("</BODY>");
         writer.println("</HTML>");
         writer.close();

--- a/src/tilda/generation/html/DocGen.java
+++ b/src/tilda/generation/html/DocGen.java
@@ -75,6 +75,7 @@ public class DocGen {
               LOG.warn("FYI: this can be ignored for now:\n", e);
             }
         }
+        writer.println("<a href='#' style='cursor: pointer;z-index: 10000; position:fixed; right:0px; bottom:0; margin:0px; padding:0px;'>Goto top</a>");
         writer.println("</BODY>");
         writer.println("</HTML>");
         writer.close();


### PR DESCRIPTION
1- Remove second duplicate Schema "section with docs"
2- Change first "Views Graph" to "Tables Graph"
4- update CSS for regular "pointer" icon when mouse over the graph vs the current "move" icon.
5- show an error if you can't find _tilda.packageInfo.json
6- eliminate the need for tilda.packageInfo.json by searching the folder for the tilde.(\w+).json pattern where group(1) is the name of the schema.
7- add the name of the picked/found tilde file to the UI after it's been picked.
8- try to have the "node and its relationships" highlight feature in the docs.