### PR TITLE
File traversing issue

### DIFF
--- a/docs/chrome-extension/js/core/file_search.js
+++ b/docs/chrome-extension/js/core/file_search.js
@@ -2,49 +2,48 @@ define(function(){
   var SCHEMA_REGEX = /\_tilda\.([A-Z][A-Za-z_0-9]+)\.json/i;
   var showFiles = function (firstEntry, excluding_regex, runAfterCompletion) {
     var directoryReader = firstEntry.createReader();
-//    var excluding_regex = excluding_regex;
+    var excluding_regex = excluding_regex;
     var files= [];
     var objectd = {};
     var counter = 0;
     var readFolder = function (entryPoint, callback) {
-      counter++;
-      directoryReader = entryPoint.createReader();
-      directoryReader.readEntries(function (entries) {
-        for (var i = 0; i < entries.length; i++) {
-          var entry = entries[i];
-//          console.log("entry: ", entry.name);
-          if (entry.isDirectory) {
-            if (entry) {
-              readFolder(entry, callback);
-            }
-          } else if (entry.isFile) {
-            var fName = entry.name;
-//            console.log("fName: ", fName);
-            if(SCHEMA_REGEX.test(fName)){
-              if(excluding_regex instanceof RegExp){
-                var full_path = entry.fullPath;
-//                console.log("full_path: ", full_path);
-                if(!excluding_regex.test(full_path)){
-//                  console.log("Not being excluded, so adding it!")
+      var readEntries = function(directoryReader){      
+        counter++;
+        directoryReader.readEntries(function (entries) {
+          console.log(entries.length+"  entries");
+          for (var i = 0; i < entries.length; i++) {
+            var entry = entries[i];
+            if (entry.isDirectory) {
+              if (entry) {
+                readFolder(entry, callback);
+              }
+            } else if (entry.isFile) {
+              var fName = entry.name;
+              if(SCHEMA_REGEX.test(fName)){
+                if(excluding_regex instanceof RegExp){
+                  var full_path = entry.fullPath;
+                  if(!excluding_regex.test(full_path)){
+                    files.push(entry);
+                  }
+                } else {
                   files.push(entry);
                 }
-                else {
-//                  console.log("Being excluded, so NOT adding it!")
-                }
-              } else {
-//                console.error("Exclusion was not a REGEX, so adding it!")
-                files.push(entry);
               }
             }
           }
-        }
-        counter--;
-        if (counter === 0 && callback) {
-          callback(files)
-        }
-      }, function (error) {
-        console.error(error);
-      });
+          if(entries.length >= 90){
+            readEntries(directoryReader);
+          }
+          counter--;
+          if (counter === 0 && callback) {
+            callback(files)
+          }
+        }, function (error) {
+          console.error(error);
+        });
+      }
+      directoryReader = entryPoint.createReader();
+      readEntries(directoryReader);
     };
     readFolder(firstEntry, runAfterCompletion);
   };


### PR DESCRIPTION
- JS filesystem apis's readEntries for directory reader limits no. of entries to 100, we need to readEntries recursively until the entries return by readEntries for a directory is 0(zero).