### PR TITLE
#150 default values on create for nullable columns - Reopened

### DIFF
--- a/src/tilda/loader/csv/stores/PostgreSQLCSVImporter.java
+++ b/src/tilda/loader/csv/stores/PostgreSQLCSVImporter.java
@@ -104,7 +104,7 @@ public class PostgreSQLCSVImporter extends CSVImporter
                     col = headers[i]; 
                     colVal = "";
                     
-                    if(DBColumns.get(col.toLowerCase()) != null)
+                    if(DBColumns.get(c.toLowerCase()) != null)
                       {                    
 	                    if(record.isMapped(col))
 	                      colVal = record.get(col);                    	
@@ -131,8 +131,8 @@ public class PostgreSQLCSVImporter extends CSVImporter
                       }
                     else 
                       {
-                        LOG.error("The column " + col + " is not found in the database for the table " + schemaName + "." + tableName + ".");                              
-                        throw new Exception("Column " + col + " not found in the database.");
+                        LOG.error("The column " + c + " is not found in the database for the table " + schemaName + "." + tableName + ".");                              
+                        throw new Exception("Column " + c + " not found in the database.");
                       }
                     
                     ColumnHeader cHeader = columnMap.get(c);

--- a/src/tilda/loader/csv/stores/PostgreSQLCSVImporter.java
+++ b/src/tilda/loader/csv/stores/PostgreSQLCSVImporter.java
@@ -109,11 +109,11 @@ public class PostgreSQLCSVImporter extends CSVImporter
 	                    if(record.isMapped(col))
 	                      colVal = record.get(col);                    	
                     	
-                        if(record.isMapped(col) == false || (TextUtil.isNullOrEmpty(colVal) && DBColumns.get(col.toLowerCase())._Nullable != 1)) 
+                        if(record.isMapped(col) == false || (TextUtil.isNullOrEmpty(colVal) && DBColumns.get(c.toLowerCase())._Nullable != 1)) 
                           {                       
                             if(TextUtil.isNullOrEmpty(columnMap.get(col)._DefaultValue) == false)                    	
                     	      colVal = columnMap.get(col)._DefaultValue;
-                            else if (DBColumns.get(col.toLowerCase())._Nullable != 1) 
+                            else if (DBColumns.get(c.toLowerCase())._Nullable != 1) 
                               {
                     	        String defaultCreateValue = MasterFactory.GetDefaultCreateValue(schemaName, tableName, col);
                     	   

--- a/src/tilda/loader/csv/stores/PostgreSQLCSVImporter.java
+++ b/src/tilda/loader/csv/stores/PostgreSQLCSVImporter.java
@@ -115,23 +115,23 @@ public class PostgreSQLCSVImporter extends CSVImporter
                     	      colVal = columnMap.get(col)._DefaultValue;
                             else if (DBColumns.get(c.toLowerCase())._Nullable != 1) 
                               {
-                    	        String defaultCreateValue = MasterFactory.GetDefaultCreateValue(schemaName, tableName, col);
+                    	        String defaultCreateValue = MasterFactory.GetDefaultCreateValue(schemaName, tableName, c);
                     	   
                     	        if(TextUtil.isNullOrEmpty(defaultCreateValue) == false)
                     	          colVal = defaultCreateValue;
                     	        else
                     	          {
-                    	            LOG.error("The column " + col + " does not have a default create value in the Tilda definition or a default value in the mapping file and is not nullable.");                  	  
+                    	            LOG.error("The header " + col + " mapped to column "+ c +" does not have a default create value in the Tilda definition or a default value in the mapping file and is not nullable.");                  	  
                     	            throw new Exception("Not null constraint will be violated.");
                     	          }
                               }
                              else
-                               LOG.info("The column " + col + " does not exist in the CSV file and does not have a default value in the mapping file.");  
+                               LOG.info("The column " + c + " does not exist in the CSV file and does not have a default value in the mapping file.");  
                            }
                       }
                     else 
                       {
-                        LOG.error("The column " + c + " is not found in the database for the table " + schemaName + "." + tableName + ".");                              
+                        LOG.error("The header " + col + " mapped to column " + c + " is not found in the database for the table " + schemaName + "." + tableName + ".");                              
                         throw new Exception("Column " + c + " not found in the database.");
                       }
                     


### PR DESCRIPTION
Fixed issue with column checks being backwards - checking source file column header vs db header. This isn't apparent when the mapping file directly maps to the db with the same column names, but when file header names differ from column header names mapped to, it causes the issue.