### PR TITLE
#134a Cryptic error when sameas is using unknown object

### DIFF
--- a/src/tilda/parsing/Parser.java
+++ b/src/tilda/parsing/Parser.java
@@ -153,7 +153,7 @@ public abstract class Parser
             break;
         if (PS.getErrorCount() == 0)
           {
-            if (PS.getSchema(BaseSchema._Package, BaseSchema._Name) == null)
+            if (PS.getSchemaForDependency(BaseSchema._Package, BaseSchema._Name) == null)
               {
                 PS.addDependencySchema(BaseSchema);
               }

--- a/src/tilda/parsing/ParserSession.java
+++ b/src/tilda/parsing/ParserSession.java
@@ -90,7 +90,7 @@ public class ParserSession
       String FullName = PackageName + "." + SchemaName;
       Schema S = _Dependencies.get(FullName);
       if (S == null)
-        LOG.debug("Schema "+ FullName +" has been found in the schema dependency list.");
+        LOG.debug("Schema "+ FullName +" has not been found in the schema dependency list.");
       return S;
     }    
     

--- a/src/tilda/parsing/ParserSession.java
+++ b/src/tilda/parsing/ParserSession.java
@@ -85,6 +85,15 @@ public class ParserSession
         return S;
       }
 
+    public Schema getSchemaForDependency(String PackageName, String SchemaName)
+    {
+      String FullName = PackageName + "." + SchemaName;
+      Schema S = _Dependencies.get(FullName);
+      if (S == null)
+        LOG.debug("Schema "+ FullName +" has been found in the schema dependency list.");
+      return S;
+    }    
+    
     public String getSchemaList()
       {
         StringBuilder Str = new StringBuilder();

--- a/src/tilda/parsing/parts/Base.java
+++ b/src/tilda/parsing/parts/Base.java
@@ -128,11 +128,9 @@ public abstract class Base
       // Mandatories
       if (TextUtil.isNullOrEmpty(_Name) == true)        	
         return PS.AddError("Schema '" + _ParentSchema.getFullName() + "' is declaring an "+getWhat()+" without a name.");
-      else 
-        {
-      	  _OriginalName = _Name;            
-          LOG.debug("  Validating "+getWhat()+" " + getFullName() + ".");
-        } 
+      
+      _OriginalName = _Name;            
+      LOG.debug("  Validating "+getWhat()+" " + getFullName() + ".");
       	
       if (ValidationHelper.isValidIdentifier(_Name) == false)
         return PS.AddError("Schema '" + _ParentSchema.getFullName() + "' is declaring "+getWhat()+" '" + getFullName() + "' with a name '"+_Name+"' which is not valid. "+ValidationHelper._ValidIdentifierMessage);

--- a/src/tilda/parsing/parts/Base.java
+++ b/src/tilda/parsing/parts/Base.java
@@ -117,34 +117,37 @@ public abstract class Base
       }
     
     protected boolean Validate(ParserSession PS, Schema ParentSchema)
-      {
-        if (_Validated == true)
-         return true;
-         
-        int Errs = PS.getErrorCount();
+    {
+      if (_Validated == true)
+       return true;
+       
+      int Errs = PS.getErrorCount();
 
-        _ParentSchema = ParentSchema;
-        LOG.debug("  Validating "+getWhat()+" " + getFullName() + ".");
+      _ParentSchema = ParentSchema;
+      
+      // Mandatories
+      if (TextUtil.isNullOrEmpty(_Name) == true)        	
+        return PS.AddError("Schema '" + _ParentSchema.getFullName() + "' is declaring an "+getWhat()+" without a name.");
+      else 
+        {
+      	  _OriginalName = _Name;            
+          LOG.debug("  Validating "+getWhat()+" " + getFullName() + ".");
+        } 
+      	
+      if (ValidationHelper.isValidIdentifier(_Name) == false)
+        return PS.AddError("Schema '" + _ParentSchema.getFullName() + "' is declaring "+getWhat()+" '" + getFullName() + "' with a name '"+_Name+"' which is not valid. "+ValidationHelper._ValidIdentifierMessage);
+      if (TextUtil.isNullOrEmpty(_Description) == true)
+        return PS.AddError("Schema '" + _ParentSchema.getFullName() + "' is declaring "+getWhat()+" '" + getFullName() + "' without a description name.");
 
-        // Mandatories
-        if (TextUtil.isNullOrEmpty(_Name) == true)
-          return PS.AddError("Schema '" + _ParentSchema.getFullName() + "' is declaring an "+getWhat()+" without a name.");
-        if (ValidationHelper.isValidIdentifier(_Name) == false)
-          return PS.AddError("Schema '" + _ParentSchema.getFullName() + "' is declaring "+getWhat()+" '" + getFullName() + "' with a name '"+_Name+"' which is not valid. "+ValidationHelper._ValidIdentifierMessage);
-        if (TextUtil.isNullOrEmpty(_Description) == true)
-          return PS.AddError("Schema '" + _ParentSchema.getFullName() + "' is declaring "+getWhat()+" '" + getFullName() + "' without a description name.");
 
-        _OriginalName = _Name;
-//        _Name = _Name.toUpperCase();
-
-        _BaseClassName = "TILDA__" + _Name.toUpperCase();
-        _AppDataClassName    = _OriginalName+"_Data";
-        _AppFactoryClassName = _OriginalName+"_Factory";
-        _AppJsonClassName = _OriginalName+"_Json";
-        
-        _Validated = Errs == PS.getErrorCount();
-        return _Validated;
-      }
+      _BaseClassName = "TILDA__" + _Name.toUpperCase();
+      _AppDataClassName    = _OriginalName+"_Data";
+      _AppFactoryClassName = _OriginalName+"_Factory";
+      _AppJsonClassName = _OriginalName+"_Json";
+      
+      _Validated = Errs == PS.getErrorCount();
+      return _Validated;
+    }
 
     protected boolean ValidateJsonMappings(ParserSession PS)
       {


### PR DESCRIPTION
For issue #134. 

**This is the second branch and commit. The original did not look correct, so to be safe I recreated the changes in a new branch.

-Broke out getSchema into separate method for dependency checking to get
the messages correct.
-Fixed null printing for objects during validation.