### PR TITLE
#184 QueryHelper getWhereClause never returns empty string.

### DIFF
--- a/src/tilda/db/QueryHelper.java
+++ b/src/tilda/db/QueryHelper.java
@@ -634,7 +634,7 @@ public abstract class QueryHelper
         if (_ST == StatementType.SELECT && _FullSelect == false)
           {
             String Str = _QueryStr.toString();
-            if (_Where == false && withWhere == true)
+            if (_Where == false && withWhere == true && TextUtil.isNullOrEmpty(Str) == false)
               Str = " where " + Str;
             return Str;
           }


### PR DESCRIPTION
-modified getWhereClause to only add where text if there are params
present.