### PR TITLE
#473 tocsv does not do sync

### DIFF
--- a/src/tilda/FolderCompare.java
+++ b/src/tilda/FolderCompare.java
@@ -114,7 +114,7 @@ public class FolderCompare
                 FileUtil.iterate(f, FSP1, new String[] {".*", "bin" });
                 BufferedWriter Out = new BufferedWriter(new FileWriter(D1.getAbsolutePath()+"\\"+f.getName()+".filecounts.csv"));
                 Out.write("Path, FileCount, FileSize, Oldest, Newest, TotalCount, TotalSize\r\n");
-                Print(Out, FSP1._Root, 0);
+                print(Out, FSP1._Root, 0);
                 Out.close();
               }
           }
@@ -126,7 +126,7 @@ public class FolderCompare
 
       }
 
-    private static void Print(Writer Out, FolderStats FS, int Level) throws IOException
+    private static void print(Writer Out, FolderStats FS, int Level) throws IOException
       {
         for (int i = 0; i < Level; ++i)
          Out.write("  ");
@@ -148,6 +148,6 @@ public class FolderCompare
         Out.write("\r\n");
         
         for (FolderStats fs : FS._Descendents)
-          Print(Out, fs, Level+1);
+          print(Out, fs, Level+1);
       }
   }

--- a/src/tilda/Import.java
+++ b/src/tilda/Import.java
@@ -46,7 +46,7 @@ public class Import
       {
         Connection C = null;
         ArrayList<String> arguments = new ArrayList<>(Arrays.asList(args));
-        ValidateParams(arguments);
+        validateParams(arguments);
 
         LOG.info("\n*************************************************************************************************************************************");
         ConnectionPool.autoInit();
@@ -81,7 +81,7 @@ public class Import
                     while (iterator.hasNext())
                       {
                         C = ConnectionPool.get(iterator.next());
-                        RecordsCount += Do(I, C);
+                        RecordsCount += process(I, C);
                         C.commit();
                         C.close();
                         C = null;
@@ -131,11 +131,11 @@ public class Import
         LOG.info("Import completed.");
       }
 
-    private static void ValidateParams(ArrayList<String> arguments)
+    private static void validateParams(ArrayList<String> arguments)
       {
         if (arguments.size() % 4 != 0)
           {
-            PrintUsageHint();
+            printUsageHint();
             System.exit(-1);
           }
 
@@ -144,14 +144,14 @@ public class Import
             if (!"-f".equals(arguments.get(i)) || TextUtil.isNullOrEmpty(arguments.get(i + 1))
             || !"-c".equals(arguments.get(i + 2)) || TextUtil.isNullOrEmpty(arguments.get(i + 3)))
               {
-                PrintUsageHint();
+                printUsageHint();
                 System.exit(-1);
               }
             i += 4;
           }
       }
 
-    private static void PrintUsageHint()
+    private static void printUsageHint()
       {
         LOG.error("");
         LOG.error("Import utility must be called with parameter(s) in following format:");
@@ -163,7 +163,7 @@ public class Import
         LOG.error("");
       }
 
-    protected static int Do(Importer I, Connection C)
+    protected static int process(Importer I, Connection C)
     throws Exception
       {
         LOG.info("");

--- a/src/tilda/data/_Tilda/TILDA__CONNECTION_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__CONNECTION_Factory.java
@@ -299,10 +299,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.Connection_Data>(Start);
+           _L = new ArrayListResults<tilda.data.Connection_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Connection_Data> OP)
          {
@@ -312,9 +312,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.Connection_Data> _OP;
        protected ArrayListResults<tilda.data.Connection_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.Connection_Data Obj = new tilda.data.Connection_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__CONNECTION)Obj).init(_C, RS);
@@ -323,24 +323,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.Connection_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.Connection_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__CONNECTION Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__CONNECTION Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -383,7 +383,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -410,7 +410,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -621,19 +621,20 @@ This is the column definition for:<BR>
        return (tilda.data.Connection_Data) Obj;
      }
 
-   static public ListResults<tilda.data.Connection_Data> lookupWhereAllById(Connection C, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.Connection_Data> lookupWhereAllById(Connection C, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__CONNECTION Obj = new tilda.data.Connection_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
 
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 1, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 1, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereAllById(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Connection_Data> OP, int Start, int Size) throws Exception
+   static public void lookupWhereAllById(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Connection_Data> OP, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__CONNECTION Obj = new tilda.data.Connection_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -641,34 +642,46 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 1, RPI, Obj, null, Start, Size);
+       readMany(C, 1, RPI, Obj, null, start, size);
      }
 
 
-   static public ListResults<tilda.data.Connection_Data> lookupWhereActive(Connection C, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.Connection_Data> lookupWhereActive(Connection C, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__CONNECTION Obj = new tilda.data.Connection_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 2, RPI, Obj, null, start, size);
        return RPI._L;
+     }
+
+
+   static public void lookupWhereActive(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Connection_Data> OP, int start, int size) throws Exception
+     {
+       tilda.data._Tilda.TILDA__CONNECTION Obj = new tilda.data.Connection_Data();
+       Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
+
+
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
+       readMany(C, 2, RPI, Obj, null, start, size);
      }
 
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.Connection_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.Connection_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Connection_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Connection_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__DATEDIM_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__DATEDIM_Factory.java
@@ -535,10 +535,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.DateDim_Data>(Start);
+           _L = new ArrayListResults<tilda.data.DateDim_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.DateDim_Data> OP)
          {
@@ -548,9 +548,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.DateDim_Data> _OP;
        protected ArrayListResults<tilda.data.DateDim_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.DateDim_Data Obj = new tilda.data.DateDim_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__DATEDIM)Obj).init(_C, RS);
@@ -559,24 +559,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.DateDim_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.DateDim_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__DATEDIM Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__DATEDIM Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -625,7 +625,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -645,7 +645,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -877,16 +877,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.DateDim_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.DateDim_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.DateDim_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.DateDim_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__DATELIMITDIM_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__DATELIMITDIM_Factory.java
@@ -118,10 +118,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.DateLimitDim_Data>(Start);
+           _L = new ArrayListResults<tilda.data.DateLimitDim_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.DateLimitDim_Data> OP)
          {
@@ -131,9 +131,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.DateLimitDim_Data> _OP;
        protected ArrayListResults<tilda.data.DateLimitDim_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.DateLimitDim_Data Obj = new tilda.data.DateLimitDim_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__DATELIMITDIM)Obj).init(_C, RS);
@@ -142,24 +142,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.DateLimitDim_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.DateLimitDim_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__DATELIMITDIM Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__DATELIMITDIM Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -186,7 +186,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -206,7 +206,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -400,16 +400,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.DateLimitDim_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.DateLimitDim_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.DateLimitDim_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.DateLimitDim_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__DEPENDENCYDDLDUMMYTABLE_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__DEPENDENCYDDLDUMMYTABLE_Factory.java
@@ -246,10 +246,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.DependencyDDLDummyTable_Data>(Start);
+           _L = new ArrayListResults<tilda.data.DependencyDDLDummyTable_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.DependencyDDLDummyTable_Data> OP)
          {
@@ -259,9 +259,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.DependencyDDLDummyTable_Data> _OP;
        protected ArrayListResults<tilda.data.DependencyDDLDummyTable_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.DependencyDDLDummyTable_Data Obj = new tilda.data.DependencyDDLDummyTable_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__DEPENDENCYDDLDUMMYTABLE)Obj).init(_C, RS);
@@ -270,24 +270,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.DependencyDDLDummyTable_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.DependencyDDLDummyTable_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__DEPENDENCYDDLDUMMYTABLE Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__DEPENDENCYDDLDUMMYTABLE Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -320,7 +320,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -340,7 +340,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -559,16 +559,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.DependencyDDLDummyTable_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.DependencyDDLDummyTable_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.DependencyDDLDummyTable_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.DependencyDDLDummyTable_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__FORMULADEPENDENCYVIEW_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__FORMULADEPENDENCYVIEW_Factory.java
@@ -213,10 +213,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.FormulaDependencyView_Data>(Start);
+           _L = new ArrayListResults<tilda.data.FormulaDependencyView_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.FormulaDependencyView_Data> OP)
          {
@@ -226,9 +226,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.FormulaDependencyView_Data> _OP;
        protected ArrayListResults<tilda.data.FormulaDependencyView_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.FormulaDependencyView_Data Obj = new tilda.data.FormulaDependencyView_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__FORMULADEPENDENCYVIEW)Obj).init(_C, RS);
@@ -237,24 +237,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.FormulaDependencyView_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.FormulaDependencyView_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__FORMULADEPENDENCYVIEW Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__FORMULADEPENDENCYVIEW Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -286,7 +286,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -307,7 +307,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -329,16 +329,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.FormulaDependencyView_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.FormulaDependencyView_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.FormulaDependencyView_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.FormulaDependencyView_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
 
 

--- a/src/tilda/data/_Tilda/TILDA__FORMULADEPENDENCY_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__FORMULADEPENDENCY_Factory.java
@@ -167,10 +167,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.FormulaDependency_Data>(Start);
+           _L = new ArrayListResults<tilda.data.FormulaDependency_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.FormulaDependency_Data> OP)
          {
@@ -180,9 +180,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.FormulaDependency_Data> _OP;
        protected ArrayListResults<tilda.data.FormulaDependency_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.FormulaDependency_Data Obj = new tilda.data.FormulaDependency_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__FORMULADEPENDENCY)Obj).init(_C, RS);
@@ -191,24 +191,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.FormulaDependency_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.FormulaDependency_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__FORMULADEPENDENCY Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__FORMULADEPENDENCY Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -237,7 +237,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -257,7 +257,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -452,16 +452,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.FormulaDependency_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.FormulaDependency_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.FormulaDependency_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.FormulaDependency_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__FORMULARESULTVIEW_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__FORMULARESULTVIEW_Factory.java
@@ -157,10 +157,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.FormulaResultView_Data>(Start);
+           _L = new ArrayListResults<tilda.data.FormulaResultView_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.FormulaResultView_Data> OP)
          {
@@ -170,9 +170,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.FormulaResultView_Data> _OP;
        protected ArrayListResults<tilda.data.FormulaResultView_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.FormulaResultView_Data Obj = new tilda.data.FormulaResultView_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__FORMULARESULTVIEW)Obj).init(_C, RS);
@@ -181,24 +181,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.FormulaResultView_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.FormulaResultView_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__FORMULARESULTVIEW Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__FORMULARESULTVIEW Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -227,7 +227,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -247,7 +247,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -268,16 +268,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.FormulaResultView_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.FormulaResultView_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.FormulaResultView_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.FormulaResultView_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
 
 

--- a/src/tilda/data/_Tilda/TILDA__FORMULARESULT_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__FORMULARESULT_Factory.java
@@ -187,10 +187,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.FormulaResult_Data>(Start);
+           _L = new ArrayListResults<tilda.data.FormulaResult_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.FormulaResult_Data> OP)
          {
@@ -200,9 +200,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.FormulaResult_Data> _OP;
        protected ArrayListResults<tilda.data.FormulaResult_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.FormulaResult_Data Obj = new tilda.data.FormulaResult_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__FORMULARESULT)Obj).init(_C, RS);
@@ -211,24 +211,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.FormulaResult_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.FormulaResult_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__FORMULARESULT Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__FORMULARESULT Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -258,7 +258,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -278,7 +278,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -475,16 +475,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.FormulaResult_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.FormulaResult_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.FormulaResult_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.FormulaResult_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__FORMULA_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__FORMULA_Factory.java
@@ -339,10 +339,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.Formula_Data>(Start);
+           _L = new ArrayListResults<tilda.data.Formula_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Formula_Data> OP)
          {
@@ -352,9 +352,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.Formula_Data> _OP;
        protected ArrayListResults<tilda.data.Formula_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.Formula_Data Obj = new tilda.data.Formula_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__FORMULA)Obj).init(_C, RS);
@@ -363,24 +363,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.Formula_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.Formula_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__FORMULA Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__FORMULA Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -420,7 +420,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -444,7 +444,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -669,19 +669,20 @@ This is the column definition for:<BR>
        return (tilda.data.Formula_Data) Obj;
      }
 
-   static public ListResults<tilda.data.Formula_Data> lookupWhereRefCols(Connection C, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.Formula_Data> lookupWhereRefCols(Connection C, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__FORMULA Obj = new tilda.data.Formula_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
 
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 2, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereRefCols(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Formula_Data> OP, int Start, int Size) throws Exception
+   static public void lookupWhereRefCols(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Formula_Data> OP, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__FORMULA Obj = new tilda.data.Formula_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -689,22 +690,22 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       readMany(C, 2, RPI, Obj, null, start, size);
      }
 
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.Formula_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.Formula_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Formula_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Formula_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__JOBPARTMESSAGE_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__JOBPARTMESSAGE_Factory.java
@@ -222,10 +222,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.JobPartMessage_Data>(Start);
+           _L = new ArrayListResults<tilda.data.JobPartMessage_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobPartMessage_Data> OP)
          {
@@ -235,9 +235,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.JobPartMessage_Data> _OP;
        protected ArrayListResults<tilda.data.JobPartMessage_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.JobPartMessage_Data Obj = new tilda.data.JobPartMessage_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__JOBPARTMESSAGE)Obj).init(_C, RS);
@@ -246,24 +246,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.JobPartMessage_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.JobPartMessage_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__JOBPARTMESSAGE Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__JOBPARTMESSAGE Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -303,7 +303,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -332,7 +332,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -532,7 +532,8 @@ This is the column definition for:<BR>
        return (tilda.data.JobPartMessage_Data) Obj;
      }
 
-   static public ListResults<tilda.data.JobPartMessage_Data> lookupWhereJob(Connection C, long jobRefnum, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.JobPartMessage_Data> lookupWhereJob(Connection C, long jobRefnum, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOBPARTMESSAGE Obj = new tilda.data.JobPartMessage_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -540,12 +541,12 @@ This is the column definition for:<BR>
        Obj.setJobRefnum    (jobRefnum    );
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 1, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 1, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereJob(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobPartMessage_Data> OP, long jobRefnum, int Start, int Size) throws Exception
+   static public void lookupWhereJob(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobPartMessage_Data> OP, long jobRefnum, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOBPARTMESSAGE Obj = new tilda.data.JobPartMessage_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -554,11 +555,12 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 1, RPI, Obj, null, Start, Size);
+       readMany(C, 1, RPI, Obj, null, start, size);
      }
 
 
-   static public ListResults<tilda.data.JobPartMessage_Data> lookupWhereJobPart(Connection C, long jobPartRefnum, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.JobPartMessage_Data> lookupWhereJobPart(Connection C, long jobPartRefnum, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOBPARTMESSAGE Obj = new tilda.data.JobPartMessage_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -566,12 +568,12 @@ This is the column definition for:<BR>
        Obj.setJobPartRefnum(jobPartRefnum);
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 2, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereJobPart(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobPartMessage_Data> OP, long jobPartRefnum, int Start, int Size) throws Exception
+   static public void lookupWhereJobPart(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobPartMessage_Data> OP, long jobPartRefnum, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOBPARTMESSAGE Obj = new tilda.data.JobPartMessage_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -580,7 +582,7 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       readMany(C, 2, RPI, Obj, null, start, size);
      }
 
 
@@ -588,16 +590,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.JobPartMessage_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.JobPartMessage_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.JobPartMessage_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.JobPartMessage_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__JOBPART_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__JOBPART_Factory.java
@@ -389,10 +389,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.JobPart_Data>(Start);
+           _L = new ArrayListResults<tilda.data.JobPart_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobPart_Data> OP)
          {
@@ -402,9 +402,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.JobPart_Data> _OP;
        protected ArrayListResults<tilda.data.JobPart_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.JobPart_Data Obj = new tilda.data.JobPart_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__JOBPART)Obj).init(_C, RS);
@@ -413,24 +413,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.JobPart_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.JobPart_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__JOBPART Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__JOBPART Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -483,7 +483,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -516,7 +516,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -726,7 +726,8 @@ This is the column definition for:<BR>
        return (tilda.data.JobPart_Data) Obj;
      }
 
-   static public ListResults<tilda.data.JobPart_Data> lookupWhereJob(Connection C, long jobRefnum, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.JobPart_Data> lookupWhereJob(Connection C, long jobRefnum, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOBPART Obj = new tilda.data.JobPart_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -734,12 +735,12 @@ This is the column definition for:<BR>
        Obj.setJobRefnum   (jobRefnum   );
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 1, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 1, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereJob(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobPart_Data> OP, long jobRefnum, int Start, int Size) throws Exception
+   static public void lookupWhereJob(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobPart_Data> OP, long jobRefnum, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOBPART Obj = new tilda.data.JobPart_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -748,11 +749,12 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 1, RPI, Obj, null, Start, Size);
+       readMany(C, 1, RPI, Obj, null, start, size);
      }
 
 
-   static public ListResults<tilda.data.JobPart_Data> lookupWhereJobPartName(Connection C, String name, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.JobPart_Data> lookupWhereJobPartName(Connection C, String name, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOBPART Obj = new tilda.data.JobPart_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -760,12 +762,12 @@ This is the column definition for:<BR>
        Obj.setName        (name        );
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 2, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereJobPartName(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobPart_Data> OP, String name, int Start, int Size) throws Exception
+   static public void lookupWhereJobPartName(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobPart_Data> OP, String name, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOBPART Obj = new tilda.data.JobPart_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -774,11 +776,12 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       readMany(C, 2, RPI, Obj, null, start, size);
      }
 
 
-   static public ListResults<tilda.data.JobPart_Data> lookupWhereJobPartType(Connection C, String type, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.JobPart_Data> lookupWhereJobPartType(Connection C, String type, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOBPART Obj = new tilda.data.JobPart_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -786,12 +789,12 @@ This is the column definition for:<BR>
        Obj.setType        (type        );
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 3, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 3, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereJobPartType(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobPart_Data> OP, String type, int Start, int Size) throws Exception
+   static public void lookupWhereJobPartType(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobPart_Data> OP, String type, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOBPART Obj = new tilda.data.JobPart_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -800,23 +803,23 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 3, RPI, Obj, null, Start, Size);
+       readMany(C, 3, RPI, Obj, null, start, size);
      }
 
 
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.JobPart_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.JobPart_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.JobPart_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.JobPart_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__JOBVIEW_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__JOBVIEW_Factory.java
@@ -582,10 +582,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.JobView_Data>(Start);
+           _L = new ArrayListResults<tilda.data.JobView_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.JobView_Data> OP)
          {
@@ -595,9 +595,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.JobView_Data> _OP;
        protected ArrayListResults<tilda.data.JobView_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.JobView_Data Obj = new tilda.data.JobView_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__JOBVIEW)Obj).init(_C, RS);
@@ -606,24 +606,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.JobView_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.JobView_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__JOBVIEW Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__JOBVIEW Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -675,7 +675,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -695,7 +695,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -724,16 +724,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.JobView_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.JobView_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.JobView_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.JobView_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
 
 

--- a/src/tilda/data/_Tilda/TILDA__JOB_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__JOB_Factory.java
@@ -391,10 +391,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.Job_Data>(Start);
+           _L = new ArrayListResults<tilda.data.Job_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Job_Data> OP)
          {
@@ -404,9 +404,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.Job_Data> _OP;
        protected ArrayListResults<tilda.data.Job_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.Job_Data Obj = new tilda.data.Job_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__JOB)Obj).init(_C, RS);
@@ -415,24 +415,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.Job_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.Job_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__JOB Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__JOB Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -481,7 +481,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -510,7 +510,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -719,7 +719,8 @@ This is the column definition for:<BR>
        return (tilda.data.Job_Data) Obj;
      }
 
-   static public ListResults<tilda.data.Job_Data> lookupWhereJobName(Connection C, String name, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.Job_Data> lookupWhereJobName(Connection C, String name, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOB Obj = new tilda.data.Job_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -727,12 +728,12 @@ This is the column definition for:<BR>
        Obj.setName       (name       );
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 1, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 1, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereJobName(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Job_Data> OP, String name, int Start, int Size) throws Exception
+   static public void lookupWhereJobName(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Job_Data> OP, String name, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOB Obj = new tilda.data.Job_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -741,11 +742,12 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 1, RPI, Obj, null, Start, Size);
+       readMany(C, 1, RPI, Obj, null, start, size);
      }
 
 
-   static public ListResults<tilda.data.Job_Data> lookupWhereJobType(Connection C, String type, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.Job_Data> lookupWhereJobType(Connection C, String type, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOB Obj = new tilda.data.Job_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -753,12 +755,12 @@ This is the column definition for:<BR>
        Obj.setType       (type       );
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 2, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereJobType(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Job_Data> OP, String type, int Start, int Size) throws Exception
+   static public void lookupWhereJobType(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Job_Data> OP, String type, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__JOB Obj = new tilda.data.Job_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -767,22 +769,22 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       readMany(C, 2, RPI, Obj, null, start, size);
      }
 
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.Job_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.Job_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Job_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Job_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__KEY_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__KEY_Factory.java
@@ -205,10 +205,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.Key_Data>(Start);
+           _L = new ArrayListResults<tilda.data.Key_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Key_Data> OP)
          {
@@ -218,9 +218,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.Key_Data> _OP;
        protected ArrayListResults<tilda.data.Key_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.Key_Data Obj = new tilda.data.Key_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__KEY)Obj).init(_C, RS);
@@ -229,24 +229,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.Key_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.Key_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__KEY Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__KEY Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -281,7 +281,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -304,7 +304,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -510,19 +510,20 @@ This is the column definition for:<BR>
        return (tilda.data.Key_Data) Obj;
      }
 
-   static public ListResults<tilda.data.Key_Data> lookupWhereAllByName(Connection C, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.Key_Data> lookupWhereAllByName(Connection C, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__KEY Obj = new tilda.data.Key_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
 
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 2, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereAllByName(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Key_Data> OP, int Start, int Size) throws Exception
+   static public void lookupWhereAllByName(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Key_Data> OP, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__KEY Obj = new tilda.data.Key_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -530,22 +531,22 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       readMany(C, 2, RPI, Obj, null, start, size);
      }
 
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.Key_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.Key_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Key_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Key_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__MAINTENANCE_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__MAINTENANCE_Factory.java
@@ -188,10 +188,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.Maintenance_Data>(Start);
+           _L = new ArrayListResults<tilda.data.Maintenance_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Maintenance_Data> OP)
          {
@@ -201,9 +201,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.Maintenance_Data> _OP;
        protected ArrayListResults<tilda.data.Maintenance_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.Maintenance_Data Obj = new tilda.data.Maintenance_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__MAINTENANCE)Obj).init(_C, RS);
@@ -212,24 +212,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.Maintenance_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.Maintenance_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__MAINTENANCE Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__MAINTENANCE Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -259,7 +259,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -279,7 +279,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -474,16 +474,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.Maintenance_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.Maintenance_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Maintenance_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Maintenance_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__MAPPING_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__MAPPING_Factory.java
@@ -189,10 +189,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.Mapping_Data>(Start);
+           _L = new ArrayListResults<tilda.data.Mapping_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Mapping_Data> OP)
          {
@@ -202,9 +202,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.Mapping_Data> _OP;
        protected ArrayListResults<tilda.data.Mapping_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.Mapping_Data Obj = new tilda.data.Mapping_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__MAPPING)Obj).init(_C, RS);
@@ -213,24 +213,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.Mapping_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.Mapping_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__MAPPING Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__MAPPING Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -260,7 +260,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -280,7 +280,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -477,16 +477,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.Mapping_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.Mapping_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Mapping_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Mapping_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__MEASUREFORMULAVIEW_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__MEASUREFORMULAVIEW_Factory.java
@@ -288,10 +288,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.MeasureFormulaView_Data>(Start);
+           _L = new ArrayListResults<tilda.data.MeasureFormulaView_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.MeasureFormulaView_Data> OP)
          {
@@ -301,9 +301,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.MeasureFormulaView_Data> _OP;
        protected ArrayListResults<tilda.data.MeasureFormulaView_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.MeasureFormulaView_Data Obj = new tilda.data.MeasureFormulaView_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__MEASUREFORMULAVIEW)Obj).init(_C, RS);
@@ -312,24 +312,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.MeasureFormulaView_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.MeasureFormulaView_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__MEASUREFORMULAVIEW Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__MEASUREFORMULAVIEW Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -364,7 +364,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -384,7 +384,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -405,16 +405,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.MeasureFormulaView_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.MeasureFormulaView_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.MeasureFormulaView_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.MeasureFormulaView_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
 
 

--- a/src/tilda/data/_Tilda/TILDA__MEASUREFORMULA_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__MEASUREFORMULA_Factory.java
@@ -167,10 +167,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.MeasureFormula_Data>(Start);
+           _L = new ArrayListResults<tilda.data.MeasureFormula_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.MeasureFormula_Data> OP)
          {
@@ -180,9 +180,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.MeasureFormula_Data> _OP;
        protected ArrayListResults<tilda.data.MeasureFormula_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.MeasureFormula_Data Obj = new tilda.data.MeasureFormula_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__MEASUREFORMULA)Obj).init(_C, RS);
@@ -191,24 +191,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.MeasureFormula_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.MeasureFormula_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__MEASUREFORMULA Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__MEASUREFORMULA Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -237,7 +237,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -257,7 +257,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -452,16 +452,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.MeasureFormula_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.MeasureFormula_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.MeasureFormula_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.MeasureFormula_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__MEASURE_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__MEASURE_Factory.java
@@ -188,10 +188,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.Measure_Data>(Start);
+           _L = new ArrayListResults<tilda.data.Measure_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.Measure_Data> OP)
          {
@@ -201,9 +201,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.Measure_Data> _OP;
        protected ArrayListResults<tilda.data.Measure_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.Measure_Data Obj = new tilda.data.Measure_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__MEASURE)Obj).init(_C, RS);
@@ -212,24 +212,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.Measure_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.Measure_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__MEASURE Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__MEASURE Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -259,7 +259,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -279,7 +279,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -487,16 +487,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.Measure_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.Measure_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Measure_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.Measure_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__OBJECTPERF_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__OBJECTPERF_Factory.java
@@ -543,10 +543,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.ObjectPerf_Data>(Start);
+           _L = new ArrayListResults<tilda.data.ObjectPerf_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.ObjectPerf_Data> OP)
          {
@@ -556,9 +556,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.ObjectPerf_Data> _OP;
        protected ArrayListResults<tilda.data.ObjectPerf_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.ObjectPerf_Data Obj = new tilda.data.ObjectPerf_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__OBJECTPERF)Obj).init(_C, RS);
@@ -567,24 +567,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.ObjectPerf_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.ObjectPerf_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__OBJECTPERF Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__OBJECTPERF Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -637,7 +637,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -667,7 +667,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -901,7 +901,8 @@ This is the column definition for:<BR>
        return (tilda.data.ObjectPerf_Data) Obj;
      }
 
-   static public ListResults<tilda.data.ObjectPerf_Data> lookupWhereSchemaByObjectStart(Connection C, String schemaName, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.ObjectPerf_Data> lookupWhereSchemaByObjectStart(Connection C, String schemaName, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__OBJECTPERF Obj = new tilda.data.ObjectPerf_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -909,12 +910,12 @@ This is the column definition for:<BR>
        Obj.setSchemaName   (schemaName   );
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 1, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 1, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereSchemaByObjectStart(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.ObjectPerf_Data> OP, String schemaName, int Start, int Size) throws Exception
+   static public void lookupWhereSchemaByObjectStart(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.ObjectPerf_Data> OP, String schemaName, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__OBJECTPERF Obj = new tilda.data.ObjectPerf_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -923,11 +924,12 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 1, RPI, Obj, null, Start, Size);
+       readMany(C, 1, RPI, Obj, null, start, size);
      }
 
 
-   static public ListResults<tilda.data.ObjectPerf_Data> lookupWhereSchemaObjectByStart(Connection C, String schemaName, String objectName, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.ObjectPerf_Data> lookupWhereSchemaObjectByStart(Connection C, String schemaName, String objectName, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__OBJECTPERF Obj = new tilda.data.ObjectPerf_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -936,12 +938,12 @@ This is the column definition for:<BR>
        Obj.setObjectName   (objectName   );
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 2, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereSchemaObjectByStart(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.ObjectPerf_Data> OP, String schemaName, String objectName, int Start, int Size) throws Exception
+   static public void lookupWhereSchemaObjectByStart(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.ObjectPerf_Data> OP, String schemaName, String objectName, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__OBJECTPERF Obj = new tilda.data.ObjectPerf_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -951,7 +953,7 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       readMany(C, 2, RPI, Obj, null, start, size);
      }
 
 
@@ -959,16 +961,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.ObjectPerf_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.ObjectPerf_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.ObjectPerf_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.ObjectPerf_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__REFILLPERF_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__REFILLPERF_Factory.java
@@ -296,10 +296,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.RefillPerf_Data>(Start);
+           _L = new ArrayListResults<tilda.data.RefillPerf_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.RefillPerf_Data> OP)
          {
@@ -309,9 +309,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.RefillPerf_Data> _OP;
        protected ArrayListResults<tilda.data.RefillPerf_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.RefillPerf_Data Obj = new tilda.data.RefillPerf_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__REFILLPERF)Obj).init(_C, RS);
@@ -320,24 +320,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.RefillPerf_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.RefillPerf_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__REFILLPERF Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__REFILLPERF Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -381,7 +381,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -411,7 +411,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -621,7 +621,8 @@ This is the column definition for:<BR>
        return (tilda.data.RefillPerf_Data) Obj;
      }
 
-   static public ListResults<tilda.data.RefillPerf_Data> lookupWhereSchemaByObjectStart(Connection C, String schemaName, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.RefillPerf_Data> lookupWhereSchemaByObjectStart(Connection C, String schemaName, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__REFILLPERF Obj = new tilda.data.RefillPerf_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -629,12 +630,12 @@ This is the column definition for:<BR>
        Obj.setSchemaName   (schemaName   );
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 1, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 1, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereSchemaByObjectStart(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.RefillPerf_Data> OP, String schemaName, int Start, int Size) throws Exception
+   static public void lookupWhereSchemaByObjectStart(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.RefillPerf_Data> OP, String schemaName, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__REFILLPERF Obj = new tilda.data.RefillPerf_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -643,11 +644,12 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 1, RPI, Obj, null, Start, Size);
+       readMany(C, 1, RPI, Obj, null, start, size);
      }
 
 
-   static public ListResults<tilda.data.RefillPerf_Data> lookupWhereSchemaObjectByStart(Connection C, String schemaName, String objectName, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.RefillPerf_Data> lookupWhereSchemaObjectByStart(Connection C, String schemaName, String objectName, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__REFILLPERF Obj = new tilda.data.RefillPerf_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -656,12 +658,12 @@ This is the column definition for:<BR>
        Obj.setObjectName   (objectName   );
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 2, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereSchemaObjectByStart(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.RefillPerf_Data> OP, String schemaName, String objectName, int Start, int Size) throws Exception
+   static public void lookupWhereSchemaObjectByStart(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.RefillPerf_Data> OP, String schemaName, String objectName, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__REFILLPERF Obj = new tilda.data.RefillPerf_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -671,23 +673,23 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 2, RPI, Obj, null, Start, Size);
+       readMany(C, 2, RPI, Obj, null, start, size);
      }
 
 
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.RefillPerf_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.RefillPerf_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.RefillPerf_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.RefillPerf_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__TRANSPERF_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__TRANSPERF_Factory.java
@@ -805,10 +805,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.TransPerf_Data>(Start);
+           _L = new ArrayListResults<tilda.data.TransPerf_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.TransPerf_Data> OP)
          {
@@ -818,9 +818,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.TransPerf_Data> _OP;
        protected ArrayListResults<tilda.data.TransPerf_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.TransPerf_Data Obj = new tilda.data.TransPerf_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__TRANSPERF)Obj).init(_C, RS);
@@ -829,24 +829,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.TransPerf_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.TransPerf_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__TRANSPERF Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__TRANSPERF Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -901,7 +901,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -921,7 +921,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -1187,16 +1187,16 @@ This is the column definition for:<BR>
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.TransPerf_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.TransPerf_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.TransPerf_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.TransPerf_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/data/_Tilda/TILDA__ZONEINFO_Factory.java
+++ b/src/tilda/data/_Tilda/TILDA__ZONEINFO_Factory.java
@@ -228,10 +228,10 @@ This is the column definition for:<BR>
      }
    private static class RecordProcessorInternal implements tilda.db.processors.RecordProcessor
      {
-       public RecordProcessorInternal(Connection C, int Start)
+       public RecordProcessorInternal(Connection C, int start)
          {
            _C = C;
-           _L = new ArrayListResults<tilda.data.ZoneInfo_Data>(Start);
+           _L = new ArrayListResults<tilda.data.ZoneInfo_Data>(start);
          }
        public RecordProcessorInternal(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.ZoneInfo_Data> OP)
          {
@@ -241,9 +241,9 @@ This is the column definition for:<BR>
        protected Connection _C = null;
        protected tilda.db.processors.ObjectProcessor<tilda.data.ZoneInfo_Data> _OP;
        protected ArrayListResults<tilda.data.ZoneInfo_Data> _L = null;
-       public void    start  () { }
-       public void    end    (boolean HasMore, int Max) { if (_OP == null) _L.wrapup(HasMore, Max); }
-       public boolean process(int Index, java.sql.ResultSet RS) throws Exception
+       public void    start  () { if (_OP != null) _OP.start(); }
+       public void    end    (boolean hasMore, int maxCount) { if (_OP == null) _L.wrapup(hasMore, maxCount); else _OP.end(hasMore, maxCount); }
+       public boolean process(int count, java.sql.ResultSet RS) throws Exception
         {
           tilda.data.ZoneInfo_Data Obj = new tilda.data.ZoneInfo_Data();
           boolean OK = ((tilda.data._Tilda.TILDA__ZONEINFO)Obj).init(_C, RS);
@@ -252,24 +252,24 @@ This is the column definition for:<BR>
              if (_OP == null)
               _L.add(Obj);
              else
-              _OP.process(Index, Obj);
+              _OP.process(count, Obj);
            }
           return OK;
         }
      }
 
-   protected static final void processMany(Connection C, String FullSelectQuery, int Start, int Size, tilda.db.processors.RecordProcessor RP) throws Exception
+   protected static final void processMany(Connection C, String fullSelectQuery, int start, int size, tilda.db.processors.RecordProcessor RP) throws Exception
      {
-       readMany(C, -77, RP, null, FullSelectQuery, Start, Size);
+       readMany(C, -77, RP, null, fullSelectQuery, start, size);
      }
-   protected static final ListResults<tilda.data.ZoneInfo_Data> readMany(Connection C, String FullSelectQuery, int Start, int Size) throws Exception
+   protected static final ListResults<tilda.data.ZoneInfo_Data> readMany(Connection C, String fullSelectQuery, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -77, RPI, null, FullSelectQuery, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -77, RPI, null, fullSelectQuery, start, size);
        return RPI._L;
      }
 
-   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__ZONEINFO Obj, Object ExtraParams, int Start, int Size) throws Exception
+   private static final void readMany(Connection C, int LookupId, tilda.db.processors.RecordProcessor RP, tilda.data._Tilda.TILDA__ZONEINFO Obj, Object ExtraParams, int start, int size) throws Exception
      {
        long T0 = System.nanoTime();
        StringBuilder S = new StringBuilder(1024);
@@ -304,7 +304,7 @@ This is the column definition for:<BR>
            }
         }
 
-       String Q = S.toString() + C.getSelectLimitClause(Start, Size+1);
+       String Q = S.toString() + C.getSelectLimitClause(start, size+1);
        S.setLength(0);
        S = null;
        QueryDetails.setLastQuery(SCHEMA_TABLENAME_LABEL, Q);
@@ -327,7 +327,7 @@ This is the column definition for:<BR>
            }
 
 
-          count = JDBCHelper.process(PS.executeQuery(), RP, Start, true, Size, true);
+          count = JDBCHelper.process(PS.executeQuery(), RP, start, true, size, true);
         }
        catch (java.sql.SQLException E)
         {
@@ -542,19 +542,20 @@ This is the column definition for:<BR>
        return (tilda.data.ZoneInfo_Data) Obj;
      }
 
-   static public ListResults<tilda.data.ZoneInfo_Data> lookupWhereAll(Connection C, int Start, int Size) throws Exception
+
+   static public ListResults<tilda.data.ZoneInfo_Data> lookupWhereAll(Connection C, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__ZONEINFO Obj = new tilda.data.ZoneInfo_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
 
 
 
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, 3, RPI, Obj, null, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, 3, RPI, Obj, null, start, size);
        return RPI._L;
      }
 
-   static public void lookupWhereAll(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.ZoneInfo_Data> OP, int Start, int Size) throws Exception
+   static public void lookupWhereAll(Connection C, tilda.db.processors.ObjectProcessor<tilda.data.ZoneInfo_Data> OP, int start, int size) throws Exception
      {
        tilda.data._Tilda.TILDA__ZONEINFO Obj = new tilda.data.ZoneInfo_Data();
        Obj.initForLookup(tilda.utils.SystemValues.EVIL_VALUE);
@@ -562,23 +563,23 @@ This is the column definition for:<BR>
 
 
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, 3, RPI, Obj, null, Start, Size);
+       readMany(C, 3, RPI, Obj, null, start, size);
      }
 
 
 
    public static SelectQuery newSelectQuery(Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, true); }
    public static SelectQuery newWhereQuery (Connection C) throws Exception { return new SelectQuery(C, SCHEMA_LABEL, TABLENAME_LABEL, false); }
-   public static ListResults<tilda.data.ZoneInfo_Data> runSelect(Connection C, SelectQuery Q, int Start, int Size) throws Exception
+   public static ListResults<tilda.data.ZoneInfo_Data> runSelect(Connection C, SelectQuery Q, int start, int size) throws Exception
      {
-       RecordProcessorInternal RPI = new RecordProcessorInternal(C, Start);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       RecordProcessorInternal RPI = new RecordProcessorInternal(C, start);
+       readMany(C, -7, RPI, null, Q, start, size);
        return RPI._L;
      }
-   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.ZoneInfo_Data> OP, int Start, int Size) throws Exception
+   public static void runSelect(Connection C, SelectQuery Q, tilda.db.processors.ObjectProcessor<tilda.data.ZoneInfo_Data> OP, int start, int size) throws Exception
      {
        RecordProcessorInternal RPI = new RecordProcessorInternal(C, OP);
-       readMany(C, -7, RPI, null, Q, Start, Size);
+       readMany(C, -7, RPI, null, Q, start, size);
      }
    public static UpdateQuery newUpdateQuery(Connection C) throws Exception { return new UpdateQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }
    public static DeleteQuery newDeleteQuery(Connection C) throws Exception { return new DeleteQuery(C, SCHEMA_LABEL, TABLENAME_LABEL); }

--- a/src/tilda/enums/SyncStatus.java
+++ b/src/tilda/enums/SyncStatus.java
@@ -25,7 +25,9 @@ public enum SyncStatus
     NEW('N')
   , UPDATED('U')
   , DELETED('D')
-  , OLD('O');
+  , OLD('O')
+  , GHOST('G')
+  ;
 
   private SyncStatus(char Status)
     {
@@ -36,7 +38,8 @@ public enum SyncStatus
   
   public static SyncStatus get(ZonedDateTime Marker, OCCObject Obj)
     {
-      return Obj.getDeleted    () != null ? ( Obj.getDeleted().isAfter(Marker) == true && Obj.getCreated().isBefore(Marker) == true ? DELETED : OLD)
+      return Obj.getCreated    ().isAfter(Marker) == true && Obj.getDeleted() != null && Obj.getDeleted().isAfter(Marker) == true ? GHOST
+           : Obj.getDeleted    () != null && Obj.getDeleted().isAfter(Marker) == true ? DELETED
            : Obj.getCreated    ().isAfter(Marker) == true ? NEW
            : Obj.getLastUpdated().isAfter(Marker) == true ? UPDATED
                                                           : OLD;

--- a/src/tilda/generation/java8/Helper.java
+++ b/src/tilda/generation/java8/Helper.java
@@ -682,7 +682,7 @@ public class Helper
         else if (C.isCollection() == false)
           Out.println("        JSONUtil.print(out, \"" + C.getName() + "\", " + First + ", Obj.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "());");
         else
-          Out.println("        JSONUtil.print(out, \"" + C.getName() + "\", " + First + ", Obj._" + C.getName() + ");");
+          Out.println("        JSONUtil.print(out, \"" + C.getName() + "\", " + First + ", Obj.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "AsArray());");
         Out.println();
         return false;
       }

--- a/src/tilda/generation/java8/Helper.java
+++ b/src/tilda/generation/java8/Helper.java
@@ -678,11 +678,11 @@ public class Helper
               }
           }
         if (C.getType() == ColumnType.JSON)
-          Out.println("        JSONUtil.printSubJson(Out, \"" + C.getName() + "\", " + First + ", Obj._" + C.getName() + ");");
+          Out.println("        JSONUtil.printSubJson(out, \"" + C.getName() + "\", " + First + ", Obj._" + C.getName() + ");");
         else if (C.isCollection() == false)
-          Out.println("        JSONUtil.print(Out, \"" + C.getName() + "\", " + First + ", Obj.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "());");
+          Out.println("        JSONUtil.print(out, \"" + C.getName() + "\", " + First + ", Obj.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "());");
         else
-          Out.println("        JSONUtil.print(Out, \"" + C.getName() + "\", " + First + ", Obj._" + C.getName() + ".toArray(new " + JavaJDBCType.getFieldTypeBaseClass(C) + "[Obj._" + C.getName() + ".size()]));");
+          Out.println("        JSONUtil.print(out, \"" + C.getName() + "\", " + First + ", Obj._" + C.getName() + ");");
         Out.println();
         return false;
       }
@@ -693,15 +693,15 @@ public class Helper
           Out.println("      Str.append(\",\");");
         if (C.getType() == ColumnType.DOUBLE || C.getType() == ColumnType.FLOAT || C.getType() == ColumnType.LONG || C.getType() == ColumnType.INTEGER
         || C.getType() == ColumnType.CHAR || C.getType() == ColumnType.BINARY || C.getType() == ColumnType.BOOLEAN)
-          Out.println("      TextUtil.escapeDoubleQuoteForCSV(Str, \"\" + " + "Data.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "());");
+          Out.println("      TextUtil.escapeDoubleQuoteForCSV(Str, \"\" + " + "obj.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "());");
         else if (C.isCollection() == true)
-          Out.println("      TextUtil.escapeDoubleQuoteForCSV(Str, " + "TextUtil.print(Data.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "(), \",\"));");
+          Out.println("      TextUtil.escapeDoubleQuoteForCSV(Str, " + "TextUtil.print(obj.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "(), \",\"));");
         else if (C.getType() == ColumnType.DATETIME)
-          Out.println("      TextUtil.escapeDoubleQuoteForCSV(Str, " + "DateTimeUtil.printDateTimeForSQL(Data.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "()));");
+          Out.println("      TextUtil.escapeDoubleQuoteForCSV(Str, " + "DateTimeUtil.printDateTimeForSQL(obj.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "()));");
         else if (C.getType() == ColumnType.DATE)
-          Out.println("      TextUtil.escapeDoubleQuoteForCSV(Str, " + "DateTimeUtil.printDate(Data.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "()));");
+          Out.println("      TextUtil.escapeDoubleQuoteForCSV(Str, " + "DateTimeUtil.printDate(obj.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "()));");
         else
-          Out.println("      TextUtil.escapeDoubleQuoteForCSV(Str, " + "Data.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "());");
+          Out.println("      TextUtil.escapeDoubleQuoteForCSV(Str, " + "obj.get" + TextUtil.capitalizeFirstCharacter(C.getName()) + "());");
         return false;
       }
 

--- a/src/tilda/generation/java8/TildaFactory.java
+++ b/src/tilda/generation/java8/TildaFactory.java
@@ -1098,6 +1098,11 @@ public class TildaFactory implements CodeGenTildaFactory
         Out.println("             out.write(\"null\\n\");");
         Out.println("             return;");
         Out.println("           }");
+        Out.println("          if (L.isEmpty() == true)");
+        Out.println("           {");
+        Out.println("             out.write(\"[]\\n\");");
+        Out.println("             return;");
+        Out.println("           }");
         Out.println("          out.write(\"[\\n\");");
         Out.println("        }");
         Out.println("      boolean First = true;");
@@ -1105,8 +1110,7 @@ public class TildaFactory implements CodeGenTildaFactory
         Out.println("       if (O!=null)");
         Out.println("        {");
         Out.println("          out.write(lead);");
-        Out.println("          if (First == false) out.write(\",\"); else { out.write(\" \"); First = false; }");
-        Out.println("          toJSON" + J._Name + "(out, O, true);");
+        Out.println("          toJSON" + J._Name + "(out, O, First == true ? \"   \" : \"  ,\", true);");
         Out.println("          out.write(\"\\n\");");
         Out.println("        }");
         Out.println("      if (fullList == true)");
@@ -1119,10 +1123,18 @@ public class TildaFactory implements CodeGenTildaFactory
         Out.println();
         Out.println("   public static void toJSON" + J._Name + "(java.io.Writer out, " + Helper.getFullAppDataClassName(J._ParentObject) + " obj, boolean fullObject) throws java.io.IOException");
         Out.println("    {");
+        Out.println("      toJSON" + J._Name + "(out, obj, \"\", fullObject);");
+        Out.println("    }");
+        Out.println();
+        Out.println("   public static void toJSON" + J._Name + "(java.io.Writer out, " + Helper.getFullAppDataClassName(J._ParentObject) + " obj, String lead, boolean fullObject) throws java.io.IOException");
+        Out.println("    {");
         Out.println("      long T0 = System.nanoTime();");
         Out.println("      " + Helper.getFullBaseClassName(J._ParentObject) + " Obj = (" + Helper.getFullBaseClassName(J._ParentObject) + ") obj;");
         Out.println("      if (fullObject == true)");
-        Out.println("       out.write(\"{\");");
+        Out.println("       {");
+        Out.println("          out.write(lead);");
+        Out.println("          out.write(\"{\");");
+        Out.println("       }");
         Out.println();
         boolean First = true;
         for (Column C : J._ColumnObjs)
@@ -1151,6 +1163,11 @@ public class TildaFactory implements CodeGenTildaFactory
             Out.println("             out.write(\"null\\n\");");
             Out.println("             return;");
             Out.println("           }");
+            Out.println("          if (L.isEmpty() == true)");
+            Out.println("           {");
+            Out.println("             out.write(\"[]\\n\");");
+            Out.println("             return;");
+            Out.println("           }");
             Out.println("          out.write(\"[\\n\");");
             Out.println("        }");
             Out.println("      boolean First = true;");
@@ -1170,6 +1187,12 @@ public class TildaFactory implements CodeGenTildaFactory
             Out.println("      PerfTracker.add(TransactionType.TILDA_TOJSON, System.nanoTime() - T0);");
             Out.println("    }");
             Out.println();
+            Out.println("   public static boolean toJSON" + J._Name + "(java.io.Writer out, " + Helper.getFullAppDataClassName(J._ParentObject) + " obj, boolean fullObject, ZonedDateTime lastSync)");
+            Out.println("   throws java.io.IOException");
+            Out.println("    {");
+            Out.println("      return toJSON" + J._Name + "(out, obj, \"\", fullObject, lastSync);");
+            Out.println("    }");
+            Out.println();
             Out.println("   public static boolean toJSON" + J._Name + "(java.io.Writer out, " + Helper.getFullAppDataClassName(J._ParentObject) + " obj, String lead, boolean fullObject, ZonedDateTime lastSync)");
             Out.println("   throws java.io.IOException");
             Out.println("    {");
@@ -1182,7 +1205,7 @@ public class TildaFactory implements CodeGenTildaFactory
             Out.println("      out.write(\" \\\"__sync\\\": \\\"\");");
             Out.println("      out.write(s._Status);");
             Out.println("      out.write(\"\\\", \");");
-            Out.println("      toJSON" + J._Name + "(out, obj, false);");
+            Out.println("      toJSON" + J._Name + "(out, obj, \"\", false);");
             Out.println("      if (fullObject == true)");
             Out.println("       out.write(\" }\\n\");");
             Out.println("      PerfTracker.add(TransactionType.TILDA_TOJSON, System.nanoTime() - T0);");

--- a/src/tilda/generation/java8/TildaFactory.java
+++ b/src/tilda/generation/java8/TildaFactory.java
@@ -1088,33 +1088,41 @@ public class TildaFactory implements CodeGenTildaFactory
     protected static void genMethodToJSON(PrintWriter Out, GeneratorSession G, OutputMapping J)
     throws Exception
       {
-        Out.println("   public static void toJSON" + J._Name + "(java.io.Writer Out, List<" + Helper.getFullAppDataClassName(J._ParentObject) + "> L, String Lead, boolean FullList) throws java.io.IOException");
+        Out.println("   public static void toJSON" + J._Name + "(java.io.Writer out, List<" + Helper.getFullAppDataClassName(J._ParentObject) + "> L, String lead, boolean fullList) throws java.io.IOException");
         Out.println("    {");
-        Out.println("      if (L == null || L.size() == 0) return;");
-        Out.println("      if (FullList == true)");
-        Out.println("       Out.write(\"[\\n\");");
+        Out.println("      long T0 = System.nanoTime();");
+        Out.println("      if (fullList == true)");
+        Out.println("        {");
+        Out.println("          if (L == null)");
+        Out.println("           {");
+        Out.println("             out.write(\"null\\n\");");
+        Out.println("             return;");
+        Out.println("           }");
+        Out.println("          out.write(\"[\\n\");");
+        Out.println("        }");
         Out.println("      boolean First = true;");
         Out.println("      for (" + Helper.getFullAppDataClassName(J._ParentObject) + " O : L)");
         Out.println("       if (O!=null)");
         Out.println("        {");
-        Out.println("          Out.write(Lead);");
-        Out.println("          if (First == false) Out.write(\",\"); else { Out.write(\" \"); First = false; }");
-        Out.println("          toJSON" + J._Name + "(Out, O, true);");
-        Out.println("          Out.write(\"\\n\");");
+        Out.println("          out.write(lead);");
+        Out.println("          if (First == false) out.write(\",\"); else { out.write(\" \"); First = false; }");
+        Out.println("          toJSON" + J._Name + "(out, O, true);");
+        Out.println("          out.write(\"\\n\");");
         Out.println("        }");
-        Out.println("      if (FullList == true)");
+        Out.println("      if (fullList == true)");
         Out.println("       { ");
-        Out.println("          Out.write(Lead);");
-        Out.println("          Out.write(\"]\\n\");");
+        Out.println("          out.write(lead);");
+        Out.println("          out.write(\"]\\n\");");
         Out.println("       } ");
+        Out.println("      PerfTracker.add(TransactionType.TILDA_TOJSON, System.nanoTime() - T0);");
         Out.println("    }");
         Out.println();
-        Out.println("   public static void toJSON" + J._Name + "(java.io.Writer Out, " + Helper.getFullAppDataClassName(J._ParentObject) + " ObjApp, boolean FullObject) throws java.io.IOException");
+        Out.println("   public static void toJSON" + J._Name + "(java.io.Writer out, " + Helper.getFullAppDataClassName(J._ParentObject) + " obj, boolean fullObject) throws java.io.IOException");
         Out.println("    {");
         Out.println("      long T0 = System.nanoTime();");
-        Out.println("      " + Helper.getFullBaseClassName(J._ParentObject) + " Obj = (" + Helper.getFullBaseClassName(J._ParentObject) + ") ObjApp;");
-        Out.println("      if (FullObject == true)");
-        Out.println("       Out.write(\"{\");");
+        Out.println("      " + Helper.getFullBaseClassName(J._ParentObject) + " Obj = (" + Helper.getFullBaseClassName(J._ParentObject) + ") obj;");
+        Out.println("      if (fullObject == true)");
+        Out.println("       out.write(\"{\");");
         Out.println();
         boolean First = true;
         for (Column C : J._ColumnObjs)
@@ -1124,59 +1132,61 @@ public class TildaFactory implements CodeGenTildaFactory
               // if (C.getType() == ColumnType.DATETIME && C.isOCCGenerated() == false)
               // First = JSONExport(Out, First, C._ParentObject.getColumn(C.getName()+"TZ"));
             }
-        Out.println("      if (FullObject == true)");
-        Out.println("       Out.write(\" }\");");
+        Out.println("      if (fullObject == true)");
+        Out.println("       out.write(\" }\");");
         Out.println("      PerfTracker.add(TransactionType.TILDA_TOJSON, System.nanoTime() - T0);");
         Out.println("    }");
 
         if (J._ParentObject.isOCC() == true && (J._ParentObject._TildaType == TildaType.OBJECT || J._ParentObject._TildaType == TildaType.VIEW) && J._Sync == true)
           {
             Out.println();
-            Out.println("   public static boolean toJSON" + J._Name + "(java.io.Writer Out, " + Helper.getFullAppDataClassName(J._ParentObject) + " Data, String ElementName, String Lead, ZonedDateTime LastSync)");
+            Out.println("   public static void toJSON" + J._Name + "(java.io.Writer out, List<" + Helper.getFullAppDataClassName(J._ParentObject) + "> L, String lead, boolean fullList, ZonedDateTime lastSync)");
             Out.println("   throws java.io.IOException");
             Out.println("    {");
-            Out.println("      SyncStatus s = SyncStatus.get(LastSync, Data);");
-            Out.println("      if (s == SyncStatus.OLD)");
-            Out.println("       return false;");
-            Out.println("      Out.write(Lead);");
-            Out.println("      if (ElementName != null)");
-            Out.println("       {");
-            Out.println("         Out.write(\"\\\"\");");
-            Out.println("         Out.write(ElementName);");
-            Out.println("         Out.write(\"\\\": \");");
-            Out.println("       }");
-            Out.println("      Out.write(\" { \\\"__sync\\\": \\\"\");");
-            Out.println("      Out.write(s._Status);");
-            Out.println("      Out.write(\"\\\", \");");
-            Out.println("      toJSON" + J._Name + "(Out, Data, false);");
-            Out.println("      Out.write(\" }\\n\");");
-            Out.println("      return true;");
-            Out.println("    }");
-            Out.println();
-            Out.println("   public static void toJSON" + J._Name + "(java.io.Writer Out, List<" + Helper.getFullAppDataClassName(J._ParentObject) + "> L, String ElementName, String Lead, ZonedDateTime LastSync)");
-            Out.println("   throws java.io.IOException");
-            Out.println("    {");
-            Out.println("      Out.write(Lead);");
-            Out.println("      if (ElementName != null)");
-            Out.println("       {");
-            Out.println("         Out.write(\"\\\"\");");
-            Out.println("         Out.write(ElementName);");
-            Out.println("         Out.write(\"\\\": \");");
-            Out.println("       }");
-            Out.println("      Out.write(\" [\\n\");");
+            Out.println("      long T0 = System.nanoTime();");
+            Out.println("      if (fullList == true)");
+            Out.println("        {");
+            Out.println("          if (L == null)");
+            Out.println("           {");
+            Out.println("             out.write(\"null\\n\");");
+            Out.println("             return;");
+            Out.println("           }");
+            Out.println("          out.write(\"[\\n\");");
+            Out.println("        }");
             Out.println("      boolean First = true;");
-            Out.println("      Lead = PaddingUtil.getPad(Lead.length());");
-            Out.println("      String LeadFirst = Lead+\"      \";");
-            Out.println("      String LeadNext  = Lead+\"    , \";");
-            Out.println("      for (" + Helper.getFullAppDataClassName(J._ParentObject) + " Data : L)");
+            Out.println("      for (" + Helper.getFullAppDataClassName(J._ParentObject) + " obj : L)");
             Out.println("       {");
-            Out.println("         if (toJSON" + J._Name + "(Out, Data, null, First == true ? LeadFirst : LeadNext, LastSync) == false)");
+            Out.println("         if (toJSON" + J._Name + "(out, obj, lead+(First==true?\"   \":\"  ,\"), true, lastSync) == false)");
             Out.println("          continue;");
+            Out.println("         out.write(\"\\n\");");
             Out.println("         if (First == true)");
             Out.println("          First = false;");
             Out.println("       }");
-            Out.println("      Out.write(Lead);");
-            Out.println("      Out.write(\"  ]\\n\");");
+            Out.println("      if (fullList == true)");
+            Out.println("       {");
+            Out.println("         out.write(lead);");
+            Out.println("         out.write(\"]\\n\");");
+            Out.println("       }");
+            Out.println("      PerfTracker.add(TransactionType.TILDA_TOJSON, System.nanoTime() - T0);");
+            Out.println("    }");
+            Out.println();
+            Out.println("   public static boolean toJSON" + J._Name + "(java.io.Writer out, " + Helper.getFullAppDataClassName(J._ParentObject) + " obj, String lead, boolean fullObject, ZonedDateTime lastSync)");
+            Out.println("   throws java.io.IOException");
+            Out.println("    {");
+            Out.println("      long T0 = System.nanoTime();");
+            Out.println("      SyncStatus s = SyncStatus.get(lastSync, obj);");
+            Out.println("      if (s == SyncStatus.OLD || s == SyncStatus.GHOST)");
+            Out.println("       return false;");
+            Out.println("      if (fullObject == true)");
+            Out.println("       out.write(\"{\");");
+            Out.println("      out.write(\" \\\"__sync\\\": \\\"\");");
+            Out.println("      out.write(s._Status);");
+            Out.println("      out.write(\"\\\", \");");
+            Out.println("      toJSON" + J._Name + "(out, obj, false);");
+            Out.println("      if (fullObject == true)");
+            Out.println("       out.write(\" }\\n\");");
+            Out.println("      PerfTracker.add(TransactionType.TILDA_TOJSON, System.nanoTime() - T0);");
+            Out.println("      return true;");
             Out.println("    }");
             Out.println();
           }
@@ -1201,22 +1211,22 @@ public class TildaFactory implements CodeGenTildaFactory
         Out.println("      return " + TextUtil.escapeDoubleQuoteWithSlash(header.toString()) + ";");
         Out.println("    }");
         Out.println();
-        Out.println("   public static void toCSV" + J._Name + "(java.io.Writer Out, List<" + Helper.getFullAppDataClassName(J._ParentObject) + "> L, boolean includeHeader) throws java.io.IOException");
+        Out.println("   public static void toCSV" + J._Name + "(java.io.Writer out, List<" + Helper.getFullAppDataClassName(J._ParentObject) + "> L, boolean includeHeader) throws java.io.IOException");
         Out.println("    {");
         Out.println("      long T0 = System.nanoTime();");
         Out.println("      if (includeHeader == true)");
-        Out.println("        Out.write(getCSVHeader" + J._Name + "() + \"\\n\");");
+        Out.println("        out.write(getCSVHeader" + J._Name + "() + \"\\n\");");
         Out.println("      for (" + Helper.getFullAppDataClassName(J._ParentObject) + " O : L)");
         Out.println("       if (O!=null)");
         Out.println("        {");
-        Out.println("          toCSV" + J._Name + "(Out, O);");
-        Out.println("          Out.write(\"\\n\");");
+        Out.println("          toCSV" + J._Name + "(out, O);");
+        Out.println("          out.write(\"\\n\");");
         Out.println("        }");
         Out.println("      PerfTracker.add(TransactionType.TILDA_TOCSV, System.nanoTime() - T0);");
         Out.println("    }");
 
         Out.println();
-        Out.println("   public static void toCSV" + J._Name + "(java.io.Writer Out, " + Helper.getFullAppDataClassName(J._ParentObject) + " Data) throws java.io.IOException");
+        Out.println("   public static void toCSV" + J._Name + "(java.io.Writer out, " + Helper.getFullAppDataClassName(J._ParentObject) + " obj) throws java.io.IOException");
         Out.println("    {");
         Out.println("      long T0 = System.nanoTime();");
         Out.println("      StringBuilder Str = new StringBuilder();");
@@ -1227,9 +1237,53 @@ public class TildaFactory implements CodeGenTildaFactory
             {
               First = Helper.CSVExport(Out, First, C);
             }
-        Out.println("      Out.write(Str.toString());");
+        Out.println("      out.write(Str.toString());");
         Out.println("      PerfTracker.add(TransactionType.TILDA_TOCSV, System.nanoTime() - T0);");
         Out.println("    }");
+        
+        if (J._ParentObject.isOCC() == true && (J._ParentObject._TildaType == TildaType.OBJECT || J._ParentObject._TildaType == TildaType.VIEW) && J._Sync == true)
+          {
+            Out.println();
+            Out.println("   public static void toCSV" + J._Name + "(java.io.Writer out, List<" + Helper.getFullAppDataClassName(J._ParentObject) + "> L, boolean includeHeader, ZonedDateTime lastSync)");
+            Out.println("   throws java.io.IOException");
+            Out.println("    {");
+            Out.println("      long T0 = System.nanoTime();");
+            Out.println("      if (includeHeader == true)");
+            Out.println("       {");
+            Out.println("         out.write(\"__sync,\");");
+            Out.println("         out.write(getCSVHeader" + J._Name + "() + \"\\n\");");
+            Out.println("       }");
+            Out.println("      for (" + Helper.getFullAppDataClassName(J._ParentObject) + " obj : L)");
+            Out.println("       {");
+            Out.println("         if (toCSV" + J._Name + "(out, obj, lastSync) == true)");
+            Out.println("          out.write(\"\\n\");");
+            Out.println("       }");
+            Out.println("      PerfTracker.add(TransactionType.TILDA_TOCSV, System.nanoTime() - T0);");
+            Out.println("    }");
+            Out.println();
+            Out.println("   public static boolean toCSV" + J._Name + "(java.io.Writer out, " + Helper.getFullAppDataClassName(J._ParentObject) + " obj, ZonedDateTime lastSync)");
+            Out.println("   throws java.io.IOException");
+            Out.println("    {");
+            Out.println("      long T0 = System.nanoTime();");
+            Out.println("      SyncStatus s = SyncStatus.get(lastSync, obj);");
+            Out.println("      if (s == SyncStatus.OLD || s == SyncStatus.GHOST)");
+            Out.println("       return false;");
+            Out.println("      StringBuilder Str = new StringBuilder();");
+            Out.println();
+            Out.println("      out.write(s._Status);");
+            Out.println("      out.write(\",\");");
+            First = true;
+            for (Column C : J._ColumnObjs)
+              if (C != null)
+                {
+                  First = Helper.CSVExport(Out, First, C);
+                }
+            Out.println("      out.write(Str.toString());");
+            Out.println("      PerfTracker.add(TransactionType.TILDA_TOCSV, System.nanoTime() - T0);");
+            Out.println("      return true;");
+            Out.println("    }");
+            Out.println();
+          }
       }
 
 

--- a/src/tilda/generation/java8/TildaFactory.java
+++ b/src/tilda/generation/java8/TildaFactory.java
@@ -1111,7 +1111,6 @@ public class TildaFactory implements CodeGenTildaFactory
         Out.println("        {");
         Out.println("          out.write(lead);");
         Out.println("          toJSON" + J._Name + "(out, O, First == true ? \"   \" : \"  ,\", true);");
-        Out.println("          out.write(\"\\n\");");
         Out.println("        }");
         Out.println("      if (fullList == true)");
         Out.println("       { ");
@@ -1145,7 +1144,7 @@ public class TildaFactory implements CodeGenTildaFactory
               // First = JSONExport(Out, First, C._ParentObject.getColumn(C.getName()+"TZ"));
             }
         Out.println("      if (fullObject == true)");
-        Out.println("       out.write(\" }\");");
+        Out.println("       out.write(\" }\\n\");");
         Out.println("      PerfTracker.add(TransactionType.TILDA_TOJSON, System.nanoTime() - T0);");
         Out.println("    }");
 
@@ -1175,7 +1174,6 @@ public class TildaFactory implements CodeGenTildaFactory
             Out.println("       {");
             Out.println("         if (toJSON" + J._Name + "(out, obj, lead+(First==true?\"   \":\"  ,\"), true, lastSync) == false)");
             Out.println("          continue;");
-            Out.println("         out.write(\"\\n\");");
             Out.println("         if (First == true)");
             Out.println("          First = false;");
             Out.println("       }");
@@ -1201,7 +1199,10 @@ public class TildaFactory implements CodeGenTildaFactory
             Out.println("      if (s == SyncStatus.OLD || s == SyncStatus.GHOST)");
             Out.println("       return false;");
             Out.println("      if (fullObject == true)");
-            Out.println("       out.write(\"{\");");
+            Out.println("       {");
+            Out.println("          out.write(lead);");
+            Out.println("          out.write(\"{\");");
+            Out.println("       }");
             Out.println("      out.write(\" \\\"__sync\\\": \\\"\");");
             Out.println("      out.write(s._Status);");
             Out.println("      out.write(\"\\\", \");");

--- a/src/tilda/generation/java8/TildaFactory.java
+++ b/src/tilda/generation/java8/TildaFactory.java
@@ -1244,27 +1244,22 @@ public class TildaFactory implements CodeGenTildaFactory
             Column nameCol = J._ColumnObjs.get(0);
             Column valCol = J._ColumnObjs.get(1);
 
-            String nameType = TextUtil.normalCapitalization(nameCol.getType().name());
-            String valType = TextUtil.normalCapitalization(valCol.getType().name());
-
-            if (nameType.equalsIgnoreCase("Char"))
-              nameType = "Character";
-            if (valType.equalsIgnoreCase("Char"))
-              valType = "Character";
+            String nameType = JavaJDBCType.getFieldTypeBaseClass(nameCol);
+            String valType = JavaJDBCType.getFieldTypeBaseClass(valCol);
 
             Out.println("   public static Map<" + nameType + ", " + valType + "> toNVP" + J._Name + "(List<" + Helper.getFullAppDataClassName(J._ParentObject) + "> L) throws Exception");
             Out.println("    {");
             Out.println("      Map<" + nameType + ", " + valType + "> M = new HashMap<" + nameType + ", " + valType + ">();");
             Out.println("      for (" + Helper.getFullAppDataClassName(J._ParentObject) + " D : L)");
             Out.println("        {");
-            Out.println("          " + valType + " val = M.get(D.get" + TextUtil.capitalizeFirstCharacter(nameCol.getName()) + "());");
-            Out.println("          if(val != null)");
-            Out.println("            throw new Exception(\"The key \" + D.get" + TextUtil.capitalizeFirstCharacter(nameCol.getName()) + "() + \" with value \" + String.valueOf(val) + \" already exists in the Map. Key values must be unique.\");");
-            if (nameCol.getType().name().equalsIgnoreCase("STRING"))
+            if (nameCol.getType() == ColumnType.STRING)
               Out.println("          if(TextUtil.isNullOrEmpty(D.get" + TextUtil.capitalizeFirstCharacter(nameCol.getName()) + "()) == false)");
-            else
+            else if (nameCol._Nullable == true)
               Out.println("          if(D.is" + TextUtil.capitalizeFirstCharacter(nameCol.getName()) + "Null() == false)");
-            Out.println("            M.put(D.get" + TextUtil.capitalizeFirstCharacter(nameCol.getName()) + "(), D.get" + TextUtil.capitalizeFirstCharacter(valCol.getName()) + "());");
+            else if (nameCol.getType().isPrimitive() == false)
+              Out.println("          if(D.get" + TextUtil.capitalizeFirstCharacter(nameCol.getName()) + "() != null)");
+            Out.println("            if (M.put(D.get" + TextUtil.capitalizeFirstCharacter(nameCol.getName()) + "(), D.get" + TextUtil.capitalizeFirstCharacter(valCol.getName()) + "()) != null)");
+            Out.println("             throw new Exception(\"The key \" + D.get" + TextUtil.capitalizeFirstCharacter(nameCol.getName()) + "() + \" with value \" + D.get" + TextUtil.capitalizeFirstCharacter(valCol.getName()) + "() + \" already exists in the Map. Key values must be unique.\");");
             Out.println("        }");
             Out.println("      return M;");
             Out.println("    }");

--- a/src/tilda/interfaces/JSONable.java
+++ b/src/tilda/interfaces/JSONable.java
@@ -17,10 +17,12 @@
 package tilda.interfaces;
 
 import java.io.Writer;
+import java.time.ZonedDateTime;
 
 
 
 public interface JSONable
   {
-    public void toJSON(Writer Out, String JsonExportName, boolean FullObject) throws Exception;
+    public void toJSON(Writer out, String jsonExportName, String lead, boolean fullObject) throws Exception;
+    public void toJSON(Writer out, String jsonExportName, String lead, boolean fullObject, ZonedDateTime lastsync) throws Exception;
   }

--- a/src/tilda/load.java
+++ b/src/tilda/load.java
@@ -56,10 +56,10 @@ import tilda.loader.ui.DataImportTableModel;
 import tilda.utils.DurationUtil;
 import tilda.utils.TextUtil;
 
-public class Load
+public class load
   {
-    protected static final Logger LOG               = LogManager.getLogger(Load.class.getName());
-    Load                          app               = null;
+    protected static final Logger LOG               = LogManager.getLogger(load.class.getName());
+    load                          app               = null;
 
     private static int            threadsCount      = 1;
     private static Object[][]     data              = null;
@@ -83,7 +83,7 @@ public class Load
 
         if (!isValidArguments(arguments))
           {
-            PrintUsageHint();
+            printUsageHint();
             System.exit(-1);
           }
 
@@ -113,8 +113,8 @@ public class Load
                 LOG.debug("Validating file " + ConfigFileName);
                 List<String> selectedObjectsList = new ArrayList<>(Arrays.asList(arguments.get(i + 3).split(",")));
                 List<String> connectionIdsList = new ArrayList<>(Arrays.asList(arguments.get(i + 5).split(",")));
-                List<DataObject> filteredObjects = FilterObjects(selectedObjectsList, Conf._CmsData);
-                List<String> errors = ValidateDataObjects(connectionIdsList, filteredObjects);
+                List<DataObject> filteredObjects = filterObjects(selectedObjectsList, Conf._CmsData);
+                List<String> errors = validateDataObjects(connectionIdsList, filteredObjects);
                 if (errors.size() > 0)
                   {
                     for (String error : errors)
@@ -128,7 +128,7 @@ public class Load
                     truncatedTables.add(DO.getTableFullName());
               }
             LOG.debug("Validation Successful.");
-            CheckTruncates(truncatedTables);
+            checkTruncates(truncatedTables);
 
             // Processing
             for (int i = 0; i < arguments.size(); i += 6)
@@ -139,8 +139,8 @@ public class Load
                 LOG.debug("Processing file " + ConfigFileName);
                 List<String> selectedObjectsList = new ArrayList<>(Arrays.asList(arguments.get(i + 3).split(",")));
                 List<String> connectionIdsList = new ArrayList<>(Arrays.asList(arguments.get(i + 5).split(",")));
-                ValidateDataObjects(connectionIdsList, Conf._CmsData);
-                StartImportProcessor(selectedObjectsList, connectionIdsList, Conf, Conf._CmsData);
+                validateDataObjects(connectionIdsList, Conf._CmsData);
+                startImportProcessor(selectedObjectsList, connectionIdsList, Conf, Conf._CmsData);
               }
             LOG.debug("Import Tables completed.");
           }
@@ -183,7 +183,7 @@ public class Load
                   {
                     try
                       {
-                        Load window = new Load();
+                        load window = new load();
                         window.frmDataImport.setVisible(true);
                       }
                     catch (Exception e)
@@ -195,7 +195,7 @@ public class Load
           }
       }
 
-    private static void CheckTruncates(Set<String> truncatedTables)
+    private static void checkTruncates(Set<String> truncatedTables)
     throws Exception
       {
         if (truncatedTables.isEmpty() == false)
@@ -211,7 +211,7 @@ public class Load
           }
       }
 
-    private static List<String> ValidateDataObjects(List<String> connectionIdsList, List<DataObject> selectedDO)
+    private static List<String> validateDataObjects(List<String> connectionIdsList, List<DataObject> selectedDO)
       {
         List<String> errorMessages = new ArrayList<>();
         Connection C = null;
@@ -247,15 +247,15 @@ public class Load
         return errorMessages;
       }
 
-    private static void StartImportProcessor(List<String> selectedObjectNames, List<String> connectionIdsList, Config conf, List<DataObject> _CmsData)
+    private static void startImportProcessor(List<String> selectedObjectNames, List<String> connectionIdsList, Config conf, List<DataObject> _CmsData)
     throws Exception
       {
-        List<DataObject> filteredObjects = FilterObjects(selectedObjectNames, _CmsData);
+        List<DataObject> filteredObjects = filterObjects(selectedObjectNames, _CmsData);
         if (connectionIdsList.size() > 0 && filteredObjects.size() > 0)
-          RunImportProcessor(connectionIdsList, conf, filteredObjects);
+          runImportProcessor(connectionIdsList, conf, filteredObjects);
       }
 
-    private static List<DataObject> FilterObjects(List<String> selectedObjects, List<DataObject> AllDataObjects)
+    private static List<DataObject> filterObjects(List<String> selectedObjects, List<DataObject> AllDataObjects)
       {
         List<DataObject> filteredList = new ArrayList<>();
 
@@ -273,7 +273,7 @@ public class Load
         return filteredList;
       }
 
-    private static void RunImportProcessor(List<String> connectionIdsList, Config Conf, List<DataObject> dataObjects)
+    private static void runImportProcessor(List<String> connectionIdsList, Config Conf, List<DataObject> dataObjects)
     throws Exception
       {
         if ("ALL".equals(connectionIdsList.get(0)))
@@ -353,7 +353,7 @@ public class Load
         return true;
       }
 
-    private static void PrintUsageHint()
+    private static void printUsageHint()
       {
         LOG.error("");
         LOG.error("Load utility *must* be called with following parameters :");
@@ -372,7 +372,7 @@ public class Load
       }
 
     // Constructor
-    public Load()
+    public load()
       {
         initialize();
         this.app = this;
@@ -441,9 +441,9 @@ public class Load
                                   }
 
                                 // Validate configurations
-                                List<DataObject> selectedDO = FilterObjects(ImportTables, Conf._CmsData);
+                                List<DataObject> selectedDO = filterObjects(ImportTables, Conf._CmsData);
                                 LOG.debug("Validating Selected Table Indices..");
-                                List<String> errors = ValidateDataObjects(ConnectionIds, selectedDO);
+                                List<String> errors = validateDataObjects(ConnectionIds, selectedDO);
                                 if (errors.size() > 0)
                                   {
                                     String error = TextUtil.joinTrim(errors.toArray(new String[errors.size()]), ", \n");
@@ -456,10 +456,10 @@ public class Load
                                 for (DataObject DO : selectedDO)
                                   if (DO.isTruncateFirst() == true)
                                     truncatedTables.add(DO.getTableFullName());
-                                CheckTruncates(truncatedTables);
+                                checkTruncates(truncatedTables);
 
                                 // Processing
-                                StartImportProcessor(ImportTables, ConnectionIds, Conf, Conf._CmsData);
+                                startImportProcessor(ImportTables, ConnectionIds, Conf, Conf._CmsData);
                                 frmDataImport.dispose(); // Doesn't trigger listeners
                                 LOG.debug("Import Tables completed.");
                               }

--- a/src/tilda/utils/EncryptionUtil.java
+++ b/src/tilda/utils/EncryptionUtil.java
@@ -58,16 +58,16 @@ public class EncryptionUtil
      */
     public static byte[] hash256(String plaintext)
       {
-        return HashByteArrray(plaintext, "SHA-256");
+        return hashByteArrray(plaintext, "SHA-256");
       }
 
     protected static String hashStr(String plaintext, String algo)
       {
-        byte[] hash = HashByteArrray(plaintext, algo);
+        byte[] hash = hashByteArrray(plaintext, algo);
         return hash == null ? null : new String(Base64.getEncoder().encodeToString(hash));
       }
 
-    protected static byte[] HashByteArrray(String plainText, String shaAlgo)
+    protected static byte[] hashByteArrray(String plainText, String shaAlgo)
       {
         if (TextUtil.isNullOrEmpty(plainText) == true)
           return null;
@@ -79,7 +79,7 @@ public class EncryptionUtil
           }
         catch (Exception e)
           {
-            LOG.error("Exception in HashByteArrray()", e);
+            LOG.error("Exception in hashByteArrray()", e);
             return null;
           }
       }

--- a/src/tilda/utils/ParseUtil.java
+++ b/src/tilda/utils/ParseUtil.java
@@ -430,7 +430,7 @@ public class ParseUtil
      * @param DefaultValue
      * @return
      */
-    public static long ParseLongPercentage(String Val, long DefaultValue)
+    public static long parseLongPercentage(String Val, long DefaultValue)
       {
         try
           {

--- a/src/tilda/utils/json/JSONUtil.java
+++ b/src/tilda/utils/json/JSONUtil.java
@@ -477,28 +477,6 @@ public class JSONUtil
         Out.write("]");
       }
 
-    public static void print(Writer Out, String Name, boolean FirstElement, Collection<String> a)
-    throws IOException
-      {
-        print(Out, Name, FirstElement);
-        if (a == null)
-          {
-            Out.write("null");
-            return;
-          }
-        Out.write("[");
-        boolean First = true;
-        for (String i : a)
-          {
-            if (First == true)
-              First = false;
-            else
-              Out.write(",");
-            printString(Out, i);
-          }
-        Out.write("]");
-      }
-
     public static void print(Writer Out, String Name, boolean FirstElement, ZonedDateTime[] a)
     throws IOException
       {
@@ -521,6 +499,28 @@ public class JSONUtil
         Out.write("]");
       }
 
+    public static void print(Writer Out, String Name, boolean FirstElement, Collection<String> a)
+    throws IOException
+      {
+        print(Out, Name, FirstElement);
+        if (a == null)
+          {
+            Out.write("null");
+            return;
+          }
+        Out.write("[");
+        boolean First = true;
+        for (String i : a)
+          {
+            if (First == true)
+              First = false;
+            else
+              Out.write(",");
+            printString(Out, i);
+          }
+        Out.write("]");
+      }
+    
     /**
      * Starts the standard JSON header for payload, i.e., {code:xxx,data:}
      * 
@@ -569,7 +569,7 @@ public class JSONUtil
         else
           {
             startOK(Out, '{');
-            Obj.toJSON(Out, JsonExportName, false);
+            Obj.toJSON(Out, JsonExportName, "", false);
             end(Out, '}');
           }
       }
@@ -630,11 +630,48 @@ public class JSONUtil
               }
             else
               Out.write(Header + "  ,");
-            Obj.toJSON(Out, JsonExportName, true);
+            Obj.toJSON(Out, JsonExportName, "", true);
             Out.write("\n");
           }
         Out.write(Header + "  ]\n");
       }
+    
+    public static void print(Writer Out, String elementName, String JsonExportName, boolean firstElement, List<? extends JSONable> L, String Header, ZonedDateTime lastSync)
+    throws Exception
+      {
+        Out.write(Header);
+        print(Out, elementName, firstElement);
+
+        if (L == null)
+          {
+            Out.write(" null ");
+            return;
+          }
+        if (L.isEmpty() == true)
+          {
+            Out.write(" [ ] ");
+            return;
+          }
+        Out.write(" [\n");
+        boolean First = true;
+        for (JSONable Obj : L)
+          {
+            if (Obj == null)
+              continue;
+            Out.write(Header);
+            if (First == true)
+              {
+                Out.write(Header + "   ");
+                First = false;
+              }
+            else
+              Out.write(Header + "  ,");
+            Obj.toJSON(Out, JsonExportName, "", true, lastSync);
+            Out.write("\n");
+          }
+        Out.write(Header + "  ]\n");
+      }
+    
 
     public static void print(Writer Out, String elementName, String JsonExportName, boolean firstElement, JSONable Obj, String Header)
     throws Exception
@@ -644,7 +681,7 @@ public class JSONUtil
         if (Obj == null)
           Out.write(" null ");
         else
-          Obj.toJSON(Out, JsonExportName, true);
+          Obj.toJSON(Out, JsonExportName, "", true);
       }
 
     public static void print(Writer Out, String elementName, boolean firstElement, String[][] Values, String Header)


### PR DESCRIPTION
#473 toCSV output methods for sync output maps are not generated.
#475 NVP OutputMaps with "nvpSrc":"ROWS" can generate code that fails if the first col is not nullable.
#474 Sync protocol for output maps should handle the "ghost" scenario.
